### PR TITLE
Small requirements.txt fix. The "yaml" module requires pyyaml. The "t…

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 halo
 openai
-textwrap
+pyyaml


### PR DESCRIPTION
Small fix to requirements.txt file.

- The 'yaml' module used is from the pyyaml package.
- The 'textwrap' module used is built in. It doesn't need to be in the requirements.txt file as it doesn't exist as an independent package.